### PR TITLE
Lava Support Changes

### DIFF
--- a/Plugin/AvalancheUtilities.cs
+++ b/Plugin/AvalancheUtilities.cs
@@ -44,7 +44,16 @@ namespace Avalanche
 
         public static void SetActionItems( string ActionItemValue, Dictionary<string, string> CustomAttributes, Person CurrentPerson, Dictionary<string, object> MergeObjects = null, string EnabledLavaCommands = "", string parameter = "" )
         {
-            var actionItems = ( ActionItemValue ?? "" ).Split( new char[] { '|' } );
+            char[] splitchar = { };
+            if ( ActionItemValue.Contains( "^" ) )
+            {
+                splitchar = new char[] { '^' };
+            }
+            else
+            {
+                splitchar = new char[] { '|' };
+            }
+            var actionItems = ( ActionItemValue ?? "" ).Split( splitchar );
 
             if ( actionItems.Length > 0 && !string.IsNullOrWhiteSpace( actionItems[0] ) )
             {

--- a/Plugin/Controls/ActionItem.cs
+++ b/Plugin/Controls/ActionItem.cs
@@ -243,12 +243,12 @@ namespace Avalanche.Controls
             {
                 if ( ddlActionList.SelectedValue == "1" || ddlActionList.SelectedValue == "2" )
                 {
-                    return string.Format( "{0}|{1}|{2}", ddlActionList.SelectedValue, ppPage.SelectedValue, tbParameter.Text );
+                    return string.Format( "{0}^{1}^{2}", ddlActionList.SelectedValue, ppPage.SelectedValue, tbParameter.Text );
                 }
 
                 if ( ddlActionList.SelectedValue == "4" )
                 {
-                    return string.Format( "{0}|{1}|{2}", ddlActionList.SelectedValue, tbTarget.Text, ddlRckipid.SelectedValue );
+                    return string.Format( "{0}^{1}^{2}", ddlActionList.SelectedValue, tbTarget.Text, ddlRckipid.SelectedValue );
                 }
 
                 return ddlActionList.SelectedValue;
@@ -256,7 +256,15 @@ namespace Avalanche.Controls
             set
             {
                 EnsureChildControls();
-                var values = value.Split( '|' );
+                string[] values = null;
+                if ( value.Contains( '^' ) )
+                {
+                    values = value.Split( '^' );
+                }
+                else
+                {
+                    values = value.Split( '|' );
+                }
                 ddlActionList.SelectedValue = values[0];
 
                 if ( ddlActionList.SelectedValue == "1" || ddlActionList.SelectedValue == "2" )

--- a/Plugin/Models/FormResponse.cs
+++ b/Plugin/Models/FormResponse.cs
@@ -17,7 +17,16 @@ namespace Avalanche.Models
 
         public void SetResponse( string attributeValue )
         {
-            var actionItems = ( attributeValue ?? "" ).Split( new char[] { '|' } );
+            char[] splitchar = { };
+            if ( attributeValue.Contains( "^" ) )
+            {
+                splitchar = new char[] { '^' };
+            }
+            else
+            {
+                splitchar = new char[] { '|' };
+            }
+            var actionItems = ( attributeValue ?? "" ).Split( splitchar );
 
             if ( actionItems.Length > 0 && !string.IsNullOrWhiteSpace( actionItems[0] ) )
             {

--- a/Plugin/Plugins/Avalanche/IconButton.ascx.cs
+++ b/Plugin/Plugins/Avalanche/IconButton.ascx.cs
@@ -64,8 +64,8 @@ namespace RockWeb.Plugins.Avalanche
                                    parameter );
 
 
-            CustomAttributes.Add( "Text", AvalancheUtilities.ProcessLava( GetAttributeValue( "Text" ), CurrentPerson, parameter ) );
-            CustomAttributes.Add( "Icon", AvalancheUtilities.ProcessLava( GetAttributeValue( "Icon" ), CurrentPerson, parameter ) );
+            CustomAttributes.Add( "Text", AvalancheUtilities.ProcessLava( GetAttributeValue( "Text" ), CurrentPerson, parameter, GetAttributeValue( "EnabledLavaCommands" ) ) );
+            CustomAttributes.Add( "Icon", AvalancheUtilities.ProcessLava( GetAttributeValue( "Icon" ), CurrentPerson, parameter, GetAttributeValue( "EnabledLavaCommands" ) ) );
 
             return new MobileBlock()
             {

--- a/Plugin/Plugins/Avalanche/TextOverImage.ascx.cs
+++ b/Plugin/Plugins/Avalanche/TextOverImage.ascx.cs
@@ -54,7 +54,11 @@ namespace RockWeb.Plugins.Avalanche
                                                                 CurrentPerson,
                                                                 "",
                                                                 GetAttributeValue( "EnabledLavaCommands" ) );
-            lLava.Text = GetAttributeValue( "Text" );
+            lLava.Text = AvalancheUtilities.ProcessLava( GetAttributeValue( "Text" ),
+                                                                                CurrentPerson,
+                                                                                "",
+                                                                                GetAttributeValue( "EnabledLavaCommands" )
+                                                                                );
         }
 
         public override MobileBlock GetMobile( string parameter )
@@ -67,7 +71,12 @@ namespace RockWeb.Plugins.Avalanche
 
             if ( !string.IsNullOrWhiteSpace( GetAttributeValue( "Text" ) ) )
             {
-                CustomAttributes["Text"] = GetAttributeValue( "Text" );
+                //CustomAttributes["Text"] = GetAttributeValue( "Text" );
+                CustomAttributes.Add( "Text", AvalancheUtilities.ProcessLava( GetAttributeValue( "Text" ),
+                                                                                CurrentPerson,
+                                                                                parameter,
+                                                                                GetAttributeValue( "EnabledLavaCommands" )
+                                                                                ) );
             }
 
             if ( GetAttributeValue( "AspectRatio" ).AsDouble() != 0 )


### PR DESCRIPTION
+ Change ActionItem field type split character to a carrot "^" character instead of "|" due to not being able to load attributes via lava. Client render/response still supports both characters for backwards compatibility.
+ Add support for Lava in text over image block.
+ Added LavaCommands support to text and icon fields